### PR TITLE
Avoid entering names consisting only of spaces.

### DIFF
--- a/01-Team-Generator/src/app/app.component.ts
+++ b/01-Team-Generator/src/app/app.component.ts
@@ -21,7 +21,7 @@ export class AppComponent {
   }
 
   onClick() {
-    if (!this.newMemberText.length) {
+    if (!this.newMemberText.trim().length) {
       this.errorMessage = "Name can't be empty";
       return;
     }


### PR DESCRIPTION
Avoid entering names consisting only of spaces but trimming extra spaces.
For example, "     " becomes "" and  "  AAAA              BBBB    " becomes "AAAA BBBB".