### PR TITLE
Don't generate teams if this.numberOfTeams is < 1

### DIFF
--- a/01-Team-Generator/src/app/app.component.ts
+++ b/01-Team-Generator/src/app/app.component.ts
@@ -34,7 +34,9 @@ export class AppComponent {
   generateTeams() {
     this.teams = [];
     const allMembers = [...this.members];
-
+    if ( this.numberOfTeams < 1 ) {
+      return;
+    }
     if (this.members.length < this.numberOfTeams) {
       this.errorMessage = 'Not enough members';
       return;


### PR DESCRIPTION
Don't generate teams if this.numberOfTeams is zero or negative, otherwise chrome 102 freezes.
The number can go below 1 if you use the spinner to change it after typing it a positive number.
Probably should show a `<p>Number of teams cannot be less than one</p>` warning too but it should be obvious enough if nothing happens.
